### PR TITLE
Unit Test CircBuffer1D

### DIFF
--- a/firmware/shared/code/circBuffer1D.c
+++ b/firmware/shared/code/circBuffer1D.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include "utils.h"
 #include "assert.h"
+#include <string.h>
 
 typedef struct
 {
@@ -129,7 +130,7 @@ uint8_t circBuffer1D_pop(const circBuffer1D_channel_E channel, uint8_t * const d
 	if (channel < CIRCBUFFER1D_CHANNEL_COUNT && circBuffer1D_getSpaceAvailable(channel)< channelData->size)
 	{
 		memset(dataToReturn, 0U, channelData->size - circBuffer1D_getSpaceAvailable(channel) );
-		for (int i=0; i < circBuffer1D_getSpaceAvailable(channel)< channelData->size, i++)
+		for (uint32_t i=0; i < channelData->size - circBuffer1D_getSpaceAvailable(channel); i++)
 		{
 			dataToReturn[i] = circBuffer1D_data.buffer[channelData->tail + channelData->startIndex];
 			channelData->tail++;

--- a/firmware/shared/code/circBuffer1D.c
+++ b/firmware/shared/code/circBuffer1D.c
@@ -121,10 +121,25 @@ bool circBuffer1D_push(const circBuffer1D_channel_E channel, const uint8_t * con
 	return ret;
 }
 
+
 uint8_t circBuffer1D_pop(const circBuffer1D_channel_E channel, uint8_t * const dataToReturn)
 {
-	UNUSED(channel);
-	UNUSED(dataToReturn);
-
-	return 0U;
+	uint8_t ret = 0;
+	circBuffer1D_channelData_S * channelData = &circBuffer1D_data.channelData[channel];
+	if (channel < CIRCBUFFER1D_CHANNEL_COUNT && circBuffer1D_getSpaceAvailable(channel)< channelData->size)
+	{
+		memset(dataToReturn, 0U, channelData->size - circBuffer1D_getSpaceAvailable(channel) );
+		for (int i=0; i < circBuffer1D_getSpaceAvailable(channel)< channelData->size, i++)
+		{
+			dataToReturn[i] = circBuffer1D_data.buffer[channelData->tail + channelData->startIndex];
+			channelData->tail++;
+			if (channelData->tail + channelData->startIndex > channelData->size)
+			{
+				channelData->tail -= channelData->size;
+			}
+		}
+		ret = channelData->size - circBuffer1D_getSpaceAvailable(channel);
+		
+	}
+	return ret;
 }

--- a/firmware/shared/code/circBuffer1D.c
+++ b/firmware/shared/code/circBuffer1D.c
@@ -145,7 +145,7 @@ bool circBuffer1D_popByte(const circBuffer1D_channel_E channel, uint8_t * const 
 uint8_t circBuffer1D_pop(const circBuffer1D_channel_E channel, uint8_t * const dataToReturn)
 {
 	uint8_t ret = 0;
-	uint8_t* returnData;
+	uint8_t *returnData = 0;
 	circBuffer1D_channelData_S * channelData = &circBuffer1D_data.channelData[channel];
 	if (channel < CIRCBUFFER1D_CHANNEL_COUNT && channelData->empty == false)
 	{

--- a/firmware/shared/code/circBuffer1D.c
+++ b/firmware/shared/code/circBuffer1D.c
@@ -145,7 +145,7 @@ bool circBuffer1D_popByte(const circBuffer1D_channel_E channel, uint8_t * const 
 uint8_t circBuffer1D_pop(const circBuffer1D_channel_E channel, uint8_t * const dataToReturn)
 {
 	uint8_t ret = 0;
-	uint8_t *returnData;
+	uint8_t* returnData;
 	circBuffer1D_channelData_S * channelData = &circBuffer1D_data.channelData[channel];
 	if (channel < CIRCBUFFER1D_CHANNEL_COUNT && channelData->empty == false)
 	{

--- a/firmware/shared/code/circBuffer1D.c
+++ b/firmware/shared/code/circBuffer1D.c
@@ -54,8 +54,8 @@ uint32_t circBuffer1D_getSpaceAvailable(const circBuffer1D_channel_E channel)
 	if(channel < CIRCBUFFER1D_CHANNEL_COUNT)
 	{
 		circBuffer1D_channelData_S * channelData = &circBuffer1D_data.channelData[channel];
-
-		if(channelData->empty == false && channelData->head == channelData->tail ){
+		if(channelData->empty == false && channelData->head == channelData->tail )
+		{
 			ret = 0;
 		}
 		else if (channelData->empty == true){
@@ -68,7 +68,6 @@ uint32_t circBuffer1D_getSpaceAvailable(const circBuffer1D_channel_E channel)
 		else if(channelData->tail > channelData->head)
 		{
 			ret =channelData->tail - channelData->head;
-		}else {
 		}
 	}
 
@@ -144,16 +143,16 @@ bool circBuffer1D_popByte(const circBuffer1D_channel_E channel, uint8_t * const 
 
 uint8_t circBuffer1D_pop(const circBuffer1D_channel_E channel, uint8_t * const dataToReturn)
 {
-	uint8_t ret = 0;
-	uint8_t *returnData = 0;
 	circBuffer1D_channelData_S * channelData = &circBuffer1D_data.channelData[channel];
+	uint8_t ret = 0;
+	uint8_t returnData[channelData->size] ;
 	if (channel < CIRCBUFFER1D_CHANNEL_COUNT && channelData->empty == false)
 	{
 		uint32_t data_size = channelData->size - circBuffer1D_getSpaceAvailable(channel);
 		memset(dataToReturn, 0U, data_size );
 		for (uint32_t i = 0U; i < data_size; i++)
 		{
-			if (circBuffer1D_popByte(channel, returnData ) == true)
+			if (circBuffer1D_popByte(channel, returnData) == true)
 			{
 			dataToReturn[i]= *returnData;
 			ret++;

--- a/firmware/shared/test/code/test_circBuffer1D/circBuffer1D_componentSpecific.c
+++ b/firmware/shared/test/code/test_circBuffer1D/circBuffer1D_componentSpecific.c
@@ -10,5 +10,5 @@
 extern const circBuffer1D_channelConfig_S circBuffer1D_channelConfig[CIRCBUFFER1D_CHANNEL_COUNT];
 const circBuffer1D_channelConfig_S circBuffer1D_channelConfig[CIRCBUFFER1D_CHANNEL_COUNT] =
 {
-	[CIRCBUFFER1D_CHANNEL_TEST_1] = { .size = 100U }
+	[CIRCBUFFER1D_CHANNEL_TEST_1] = { .size = 8U }
 };

--- a/firmware/shared/test/code/test_circBuffer1D/test_circBuffer1D.c
+++ b/firmware/shared/test/code/test_circBuffer1D/test_circBuffer1D.c
@@ -18,7 +18,7 @@ Ensure(test_circBuffer1D)
 	uint8_t returnData[8];
 
 	//performs test 2 times with a 1D buffer with size of 8U
-	for(circBuffer1D_channel_E channel = CIRCBUFFER1D_CHANNEL_TEST_1; channel < CIRCBUFFER1D_CHANNEL_COUNT * 2 + 1 ; channel += 2)
+	for(circBuffer1D_channel_E channel = CIRCBUFFER1D_CHANNEL_TEST_1; channel < CIRCBUFFER1D_CHANNEL_COUNT * 2 + 1  ; channel += 2)
     {
 		circBuffer1D_channel_E testChannel = channel % 2;
 
@@ -77,15 +77,17 @@ Ensure(test_circBuffer1D)
 		// Tries to push when the buffer channel is full, checks to ensure failure
 		chk = circBuffer1D_push(testChannel, data, 8U);
 		assert_that(chk, is_equal_to(0U));
-        
+       
 		// Tests getSpaceAvailable to make sure it recognizes a full buffer channel
 		result = circBuffer1D_getSpaceAvailable(testChannel);
 		assert_that(result, is_equal_to(0U));
 
+        
+
 		//Pops all of the slots of the buffer channel, ensures data being popped matches the data pushed
             chk = circBuffer1D_pop(testChannel, returnData);
 		    assert_that(chk, is_equal_to(8U));
-        for(int i = 0; i < 8 ; i++)
+         for(int i = 0; i < 8 ; i++)
         {  
 			assert_that(returnData[i], is_equal_to(2*i+1));
 		}
@@ -93,7 +95,8 @@ Ensure(test_circBuffer1D)
         // Tests getSpaceAvailable to make sure it recognizes an empty buffer channel
 		result = circBuffer1D_getSpaceAvailable(testChannel);
 		assert_that(result, is_equal_to(8U));
-	}
+	
+    }
 }
 
 int main(int argc, char **argv)

--- a/firmware/shared/test/code/test_circBuffer1D/test_circBuffer1D.c
+++ b/firmware/shared/test/code/test_circBuffer1D/test_circBuffer1D.c
@@ -1,27 +1,107 @@
 
 #include <cgreen/cgreen.h>
 #include "circBuffer1D.h"
-
+#include "circBuffer1D_componentSpecific.h"
 
 Describe(Cgreen);
 BeforeEach(Cgreen) {}
 AfterEach(Cgreen) {}
 
-Ensure(test_circBuffer1D_addToBuffer)
+Ensure(test_circBuffer1D)
 {
-//    assert_that(1U, is_equal_to(0U));
-    uint8_t data[10U] = {0U};
-    bool ret = circBuffer1D_popByte(CIRCBUFFER1D_CHANNEL_TEST_1, data);
-    assert_that(ret, is_equal_to(0U));
-}
+    circBuffer1D_init();
 
+    uint32_t result = 0U;
+	uint8_t chk = 0U;
+
+	uint8_t data[] = {1U, 3U, 5U, 7U, 9U, 11U, 13U, 15U};
+	uint8_t returnData[8];
+
+	//performs test 2 times with a 1D buffer with size of 8U
+	for(circBuffer1D_channel_E channel = CIRCBUFFER1D_CHANNEL_TEST_1; channel < CIRCBUFFER1D_CHANNEL_COUNT * 2 + 1 ; channel += 2)
+    {
+		circBuffer1D_channel_E testChannel = channel % 2;
+
+		
+
+        //Push to first 3 slots of the buffer channel, check each push is successful
+        for (int i = 0; i < 3 ; i++)
+        {
+            chk = circBuffer1D_pushByte(testChannel, data[i]);
+            assert_that(chk, is_equal_to(1U));
+        }
+
+        //Tests getSpaceAvailable to make sure it recognizes an partly filled buffer channel
+        result = circBuffer1D_getSpaceAvailable(testChannel);
+        assert_that(result, is_equal_to(5U));
+
+        //Pop 2 oldest slots of the buffer channel, check each pop is successful and data being popped matches the data pushed
+        for (int i = 0; i < 2 ; i++)
+        {
+            chk = circBuffer1D_popByte(testChannel, returnData);
+            assert_that(chk, is_equal_to(1U));
+            assert_that(*returnData, is_equal_to(2*i+1));
+        }
+
+        //Push to next slot of the buffer channel, check each push is successful
+        for (int i = 3; i < 4 ; i++)
+        {
+            chk = circBuffer1D_pushByte(testChannel, data[i]);
+            assert_that(chk, is_equal_to(1U));
+        }
+
+        //Tests getSpaceAvailable to make sure it recognizes an partly filled buffer channel
+        result = circBuffer1D_getSpaceAvailable(testChannel);
+        assert_that(result, is_equal_to(6U));
+
+        //Pop 4 oldest slots of the buffer channel, check each pop is successful and data being popped matched the data pushed
+        for (int i = 2; i < 4 ; i++)
+        {
+            chk = circBuffer1D_popByte(testChannel, returnData);
+            assert_that(chk, is_equal_to(1U));
+            assert_that(*returnData, is_equal_to(2*i+1));
+        }
+
+       // Tries to pop an empty buffer channel, ensures failure
+		chk = circBuffer1D_pop(testChannel, returnData);
+		assert_that(chk, is_equal_to(0U));
+
+		// Tests getSpaceAvailable to make sure it recognizes an empty buffer channel
+		result = circBuffer1D_getSpaceAvailable(testChannel);
+		assert_that(result, is_equal_to(8U));
+      
+		// Pushes to all of the slots of the buffer channel, checks push is successful
+        	chk = circBuffer1D_push(testChannel, data, 8U);
+			assert_that(chk, is_equal_to(1U));
+	      
+		// Tries to push when the buffer channel is full, checks to ensure failure
+		chk = circBuffer1D_push(testChannel, data, 8U);
+		assert_that(chk, is_equal_to(0U));
+        
+		// Tests getSpaceAvailable to make sure it recognizes a full buffer channel
+		result = circBuffer1D_getSpaceAvailable(testChannel);
+		assert_that(result, is_equal_to(0U));
+
+		//Pops all of the slots of the buffer channel, ensures data being popped matches the data pushed
+            chk = circBuffer1D_pop(testChannel, returnData);
+		    assert_that(chk, is_equal_to(8U));
+        for(int i = 0; i < 8 ; i++)
+        {  
+			assert_that(returnData[i], is_equal_to(2*i+1));
+		}
+
+        // Tests getSpaceAvailable to make sure it recognizes an empty buffer channel
+		result = circBuffer1D_getSpaceAvailable(testChannel);
+		assert_that(result, is_equal_to(8U));
+	}
+}
 
 int main(int argc, char **argv)
 {
 
     TestSuite *suite = create_named_test_suite("test_circBuffer1D");
 
-    add_test(suite, test_circBuffer1D_addToBuffer);
+    add_test(suite, test_circBuffer1D);
 
     return run_test_suite(suite, create_text_reporter());
 }


### PR DESCRIPTION
_Test for 2 loops including: 
   +pushByte 3 times to an empty buffer channel
   +getSpaceAvailable 1 time to check if it can recognize partly filled buffer channel
   +popByte 2 times to check data popped is matched
   +pushByte 1 times to a partly filled buffer channel
   +popByte 5 times to check what happens if trying to popByte from an empty buffer channel
   +getSpaceAvailable 1 time to ensure it can recognize an empty buffer channel
   +push 1 time to push to all slots of buffer channel
   +push 1 time to see what happens if trying to push to a full buffer channel
   +getSpaceAvailable 1 time to ensure it can recognize a full buffer channel
   +pop 1 time to check data popped is matched
   +getSpaceAvailable 1 time to ensure all data was popped from buffer channel
_Bugs: Segmentation Fault. It happens when I create a pointer returnData which initially points to uint8_t (0) in function circBuffer1D_pop. This pointer is use to get the value from a buffer channel after calling the function circBuffer1D_popByte. I fixed this by making the returnData as an array instead. 